### PR TITLE
hash FrozenOrderedSet equal to frozenset

### DIFF
--- a/orderedsets/__init__.py
+++ b/orderedsets/__init__.py
@@ -25,6 +25,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
+import sys
+
 try:
     import importlib.metadata as importlib_metadata
 except ModuleNotFoundError:  # pragma: no cover
@@ -180,10 +182,15 @@ class FrozenOrderedSet(Set):  # type: ignore[type-arg]
             self._dict = \
                 immutabledict.fromkeys(base)
 
-    # See
-    # https://github.com/python/cpython/blob/4a1026077af65b308c98cdfe181b5f94c46fb48a/Lib/_collections_abc.py#L665
-    # for why we are using this hash implementation.
-    __hash__ = Set._hash  # type: ignore[assignment]
+
+    if sys.version_info >= (3, 9):
+        # See
+        # https://github.com/python/cpython/blob/4a1026077af65b308c98cdfe181b5f94c46fb48a/Lib/_collections_abc.py#L665
+        # for why we are using this hash implementation.
+        __hash__ = Set._hash
+    else:
+        def __hash__(self) -> int:
+            return hash(frozenset(self._dict))
 
     def __repr__(self) -> str:
         if len(self) == 0:

--- a/orderedsets/__init__.py
+++ b/orderedsets/__init__.py
@@ -181,7 +181,7 @@ class FrozenOrderedSet(Set):  # type: ignore[type-arg]
                 immutabledict.fromkeys(base)
 
     def __hash__(self) -> int:
-        return hash(type(self)) ^ hash(self._dict)
+        return hash(frozenset(self))
 
     def __repr__(self) -> str:
         if len(self) == 0:

--- a/orderedsets/__init__.py
+++ b/orderedsets/__init__.py
@@ -182,13 +182,12 @@ class FrozenOrderedSet(Set):  # type: ignore[type-arg]
             self._dict = \
                 immutabledict.fromkeys(base)
 
-
-    if sys.version_info >= (3, 9):
+    if sys.version_info >= (3, 9):  # pragma: no cover
         # See
         # https://github.com/python/cpython/blob/4a1026077af65b308c98cdfe181b5f94c46fb48a/Lib/_collections_abc.py#L665
         # for why we are using this hash implementation.
         __hash__ = Set._hash
-    else:
+    else:  # pragma: no cover
         def __hash__(self) -> int:
             return hash(frozenset(self._dict))
 

--- a/orderedsets/__init__.py
+++ b/orderedsets/__init__.py
@@ -180,8 +180,10 @@ class FrozenOrderedSet(Set):  # type: ignore[type-arg]
             self._dict = \
                 immutabledict.fromkeys(base)
 
-    def __hash__(self) -> int:
-        return hash(frozenset(self))
+    # See
+    # https://github.com/python/cpython/blob/4a1026077af65b308c98cdfe181b5f94c46fb48a/Lib/_collections_abc.py#L665
+    # for why we are using this hash implementation.
+    __hash__ = Set._hash  # type: ignore[assignment]
 
     def __repr__(self) -> str:
         if len(self) == 0:

--- a/test/test_orderedsets.py
+++ b/test/test_orderedsets.py
@@ -139,6 +139,14 @@ def test_hash(_cls: Any) -> None:
         assert hash(s1) != hash(s3)
 
 
+def test_hash_value() -> None:
+    fos = FrozenOrderedSet([1, 2, 3])
+    fs = frozenset([1, 2, 3])
+
+    assert fs == fos
+    assert hash(fs) == hash(fos)
+
+
 @all_set_types
 def test_update(_cls: Any) -> None:
     s = _cls([1, 6, 8])


### PR DESCRIPTION
See e.g. https://github.com/python/cpython/blob/4a1026077af65b308c98cdfe181b5f94c46fb48a/Lib/_collections_abc.py#L665 for reference.


> ```python
> def _hash(self):
>     """Compute the hash value of a set.
>     
>     Note that we don't define __hash__: not all sets are hashable.
>     But if you define a hashable set type, its __hash__ should
>     call this function.
>     
>     This must be compatible __eq__.
>     
>     All sets ought to compare equal if they contain the same
>     elements, regardless of how they are implemented, and
>     regardless of the order of the elements; so there's not much
>     freedom for __eq__ or __hash__.  We match the algorithm used
>     by the built-in frozenset type.
>     """
>    ```