### PR TITLE
use pytools.memoize for caching

### DIFF
--- a/orderedsets/__init__.py
+++ b/orderedsets/__init__.py
@@ -37,6 +37,7 @@ from collections.abc import Iterator, Set
 from typing import AbstractSet, Any, Dict, Iterable, Optional, TypeVar
 
 from immutabledict import immutabledict
+from pytools import memoize_method
 
 T = TypeVar("T")
 
@@ -229,16 +230,10 @@ class FrozenOrderedSet(AbstractSet[T]):
             self._dict = \
                 immutabledict.fromkeys(items)
 
-        self._my_hash: Optional[int] = None
-        self._len: Optional[int] = None
-
+    @memoize_method
     def __hash__(self) -> int:
         """Return a hash of this set."""
-        if self._my_hash:
-            return self._my_hash
-
-        self._my_hash = hash(frozenset(self))
-        return self._my_hash
+        return hash(frozenset(self))
 
     def __eq__(self, other: object) -> bool:
         """Return whether this set is equal to *other*."""
@@ -246,19 +241,17 @@ class FrozenOrderedSet(AbstractSet[T]):
                 and len(self) == len(other)
                 and all(i in other for i in self))
 
+    @memoize_method
     def __repr__(self) -> str:
         """Return a string representation of this set."""
         if len(self) == 0:
             return "FrozenOrderedSet()"
         return "FrozenOrderedSet({" + ", ".join(list(map(str, self._dict))) + "})"
 
+    @memoize_method
     def __len__(self) -> int:
         """Return the number of elements in this set."""
-        if self._len:
-            return self._len
-
-        self._len = len(self._dict)
-        return self._len
+        return len(self._dict)
 
     def __contains__(self, o: object) -> bool:
         """Return whether *o* is in this set."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ authors = [
 description = "An implementation of mutable and immutable ordered sets."
 dependencies = [
     "immutabledict",
+    "pytools",
 ]
 readme = "README.md"
 license = { file="LICENSE" }


### PR DESCRIPTION
```python
from orderedsets import FrozenOrderedSet
from pickle import dump, load

f1 = FrozenOrderedSet(["a", "b", "c"])
hash(f1)  # Force creating a cached hash value

try:
    with open("pickle.pkl", "rb") as f:
        f2 = load(f)
except FileNotFoundError:
    f2 = FrozenOrderedSet(["a", "b", "c"])
    with open("pickle.pkl", "wb") as f:
        dump(f1, f)

assert f1 == f2
print(hash(f1), hash(f2))
assert hash(f1) == hash(f2)
```

```console
$ python pickletest.py
-1463126130771402869 -1463126130771402869
$ python pickletest.py
8982062539535066463 -1463126130771402869
Traceback (most recent call last):
  File "/Users/mdiener/Work/orderedsets/pickletest.py", line 61, in <module>
    assert hash(f1) == hash(f2)
           ^^^^^^^^^^^^^^^^^^^^
AssertionError
```